### PR TITLE
Fix the migration errors in 1_2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# JetBrains
+/.idea/

--- a/Migrations/Schema/v1_2/ChangeSerializedDataFieldType.php
+++ b/Migrations/Schema/v1_2/ChangeSerializedDataFieldType.php
@@ -70,6 +70,15 @@ class ChangeSerializedDataFieldType implements
 
     private function moveData(string $tableName, string $tempTableName, Column $idColumn)
     {
+        if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+            $tempTableExists = $this->connection->executeQuery("SHOW TABLES LIKE '$tempTableName'")->fetchOne();
+        } else {
+            $tempTableExists = $this->connection->executeQuery("SELECT to_regclass('public.$tempTableName')")->fetchOne();
+        }
+        if (!$tempTableExists) {
+            return;
+        }
+        
         $sourceIdColumn = $idColumn->getName();
 
         if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
@@ -112,6 +121,12 @@ class ChangeSerializedDataFieldType implements
 
     private function updateEntityConfig(QueryBag $queries, array $entityConfig): void
     {
+        if (!isset(
+            $entityConfig['id'],
+            $entityConfig['data']['extend']['schema']['entity']
+        )) {
+            return ;
+        }
         $data = $entityConfig['data'];
         $exClass = $data['extend']['schema']['entity'];
         $fieldName = 'serialized_data';

--- a/Migrations/Schema/v1_2/MoveSerializedDataToTempTables.php
+++ b/Migrations/Schema/v1_2/MoveSerializedDataToTempTables.php
@@ -3,6 +3,7 @@
 namespace Oro\Bundle\EntitySerializedFieldsBundle\Migrations\Schema\v1_2;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Query\QueryException;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -99,7 +100,25 @@ class MoveSerializedDataToTempTables implements
             }
 
             $this->connection->executeQuery("UPDATE $tableName SET serialized_data = NULL");
-            $this->connection->executeQuery("CREATE INDEX {$tempTableName}_id_idx ON $tempTableName (id)");
+            $indexName = "{$tempTableName}_id_idx";
+            if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+                $tempTableExists = $this->connection->executeQuery("SHOW TABLES LIKE '$tempTableName'")->fetchOne(); 
+                if ($tempTableExists) {
+                    /** @var $result \Doctrine\DBAL\ForwardCompatibility\Result */
+                    $result = $this->connection->executeQuery("SHOW INDEX FROM $tempTableName WHERE KEY_NAME = '$indexName'");
+                    if ($result->fetchAllNumeric()[0][0] ?? 0) {
+                        $this->connection->executeQuery("DROP INDEX $indexName ON $tempTableName");
+                    }
+                }
+            } else {
+                $tempTableExists = $this->connection->executeQuery("SELECT to_regclass('public.$tempTableName')")->fetchOne();
+                if ($tempTableExists) {
+                    $this->connection->executeQuery("DROP INDEX IF EXISTS $indexName");
+                }
+            }
+            if ($tempTableExists) {
+                $this->connection->executeQuery("CREATE INDEX $indexName ON $tempTableName (id)");
+            }
         }
     }
 }


### PR DESCRIPTION
Fix the migrations reporting errors of: table not found, index not found, undefined key.

* Added checks based on the DB platform.
* Safely ignore the procedure if table or index not found.
* added `.gitignore` file