### PR TITLE
fix getEntities from SerializedDataMigrationQuery for custom entities

### DIFF
--- a/Migration/SerializedDataMigrationQuery.php
+++ b/Migration/SerializedDataMigrationQuery.php
@@ -155,7 +155,7 @@ class SerializedDataMigrationQuery extends ParametrizedMigrationQuery
             $options = $this->schema->getExtendOptions();
             foreach ($options as $key => $value) {
                 if ($this->isTableOptions($key)
-                    && !empty($config['extend']['is_extend'])
+                    && !empty($value['extend']['is_extend'])
                     && isset($value[ExtendOptionsManager::ENTITY_CLASS_OPTION])
                     && (
                         !isset($value[ExtendOptionsManager::MODE_OPTION])


### PR DESCRIPTION
It sometimes generates errors in oro:install in test mode if the last entity from the previous foreach had is_extend = false  : 

`17:49:22  Running full re-indexation with "oro:search:reindex" command
17:49:23  Started reindex task for all mapped entities
17:49:25  
17:49:25  In BufferedIdentityQueryResultIterator.php line 270:
17:49:25                                                                                 
17:49:25    Can not autodetect row identifier, set custom iteration strategy to handle   
17:49:25    complex query.                                                               
17:49:25                                                                                 
17:49:25  
17:49:25  In AbstractPostgreSQLDriver.php line 79:
17:49:25                                                                                 
17:49:25    An exception occurred while executing 'SELECT o0_.id AS id_0, o0_.name AS n  
17:49:25    ame_1, o0_.testMultienumField_ss AS testmultienumfield_ss_2, o0_.serialized  
17:49:25    _data AS serialized_data_3, o0_.biM2OTarget_id AS bim2otarget_id_4, o0_.def  
17:49:25    ault_biM2MTargets_id AS default_bim2mtargets_id_5, o0_.default_biO2MTargets  
17:49:25    _id AS default_bio2mtargets_id_6, o0_.uniM2OTarget_id AS unim2otarget_id_7,  
17:49:25     o0_.default_uniM2MTargets_id AS default_unim2mtargets_id_8, o0_.default_un  
17:49:25    iO2MTargets_id AS default_unio2mtargets_id_9, o0_.testEnumField_id AS teste  
17:49:25    numfield_id_10 FROM oro_ext_testentity1 o0_ WHERE o0_.id IN (NULL) ORDER BY  
17:49:25     o0_.id ASC':                                                                
17:49:25                                                                                 
17:49:25    SQLSTATE[42703]: Undefined column: 7 ERROR:  column o0_.serialized_data doe  
17:49:25    s not exist                                                                  
17:49:25    LINE 1: ...testMultienumField_ss AS testmultienumfield_ss_2, o0_.serial...   
17:49:25                                                                 ^               
17:49:25                                                                                 
17:49:25  
17:49:25  In Exception.php line 18:
17:49:25                                                                                 
17:49:25    SQLSTATE[42703]: Undefined column: 7 ERROR:  column o0_.serialized_data doe  
17:49:25    s not exist                                                                  
17:49:25    LINE 1: ...testMultienumField_ss AS testmultienumfield_ss_2, o0_.serial...   
17:49:25                                                                 ^               
17:49:25                                                                                 
17:49:25  
17:49:25  In PDOStatement.php line 117:
17:49:25                                                                                 
17:49:25    SQLSTATE[42703]: Undefined column: 7 ERROR:  column o0_.serialized_data doe  
17:49:25    s not exist                                                                  
17:49:25    LINE 1: ...testMultienumField_ss AS testmultienumfield_ss_2, o0_.serial...   
17:49:25                                                                 ^               
17:49:25                                                                                 
17:49:25  
17:49:25  oro:search:reindex [--scheduled] [--] [<class>]
17:49:25  ` 