### PR TITLE
Fixes #1124 removeFoo() calls on multiEnum fields now remove values

### DIFF
--- a/EntityExtend/SerializedEntityFieldExtension.php
+++ b/EntityExtend/SerializedEntityFieldExtension.php
@@ -186,10 +186,11 @@ class SerializedEntityFieldExtension extends AbstractEntityFieldExtension implem
                 $serialized[$transport->getName()] = array_values($serialized[$transport->getName()]);
             }
         }
-        if (isset($normalized[$transport->getValue()])) {
+        if (isset($normalized[$transport->getName()])) {
             $normalizedKey = array_search($value, $normalized[$transport->getName()]);
             if (false !== $normalizedKey) {
-                unset($serialized[$transport->getName()][$normalizedKey]);
+                unset($normalized[$transport->getName()][$normalizedKey]);
+                $normalized[$transport->getName()] = array_values($normalized[$transport->getName()]);
             }
         }
         $transport->setProcessed(true);


### PR DESCRIPTION
There appears to have been some copy/paste confusion that prevented the enum option from being removed from both serialized and normalized arrays.  This resolves issue #1124.